### PR TITLE
Fix crash about missing NSSpeechRecognitionUsageDescription

### DIFF
--- a/Standups.xcodeproj/project.pbxproj
+++ b/Standups.xcodeproj/project.pbxproj
@@ -521,6 +521,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"Standups/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "To transcribe meeting notes.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -549,6 +550,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"Standups/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "To transcribe meeting notes.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;


### PR DESCRIPTION
There was just a missing `NSSpeechRecognitionUsageDescription` info plist key in the project migration