### PR TITLE
Prevent retain cycles

### DIFF
--- a/SyncUps/Dependencies/SpeechClient.swift
+++ b/SyncUps/Dependencies/SpeechClient.swift
@@ -16,7 +16,6 @@ struct SpeechClient {
 
 extension SpeechClient: DependencyKey {
   static var liveValue: SpeechClient {
-    let speech = Speech()
     return SpeechClient(
       authorizationStatus: { SFSpeechRecognizer.authorizationStatus() },
       requestAuthorization: {
@@ -27,7 +26,8 @@ extension SpeechClient: DependencyKey {
         }
       },
       startTask: { request in
-        await speech.startTask(request: request)
+        let speech = Speech()
+        return await speech.startTask(request: request)
       }
     )
   }
@@ -168,6 +168,7 @@ private actor Speech {
 
       continuation.onTermination = { [audioEngine, recognitionTask] _ in
         _ = speechRecognizer
+        _ = self
         audioEngine?.stop()
         audioEngine?.inputNode.removeTap(onBus: 0)
         recognitionTask?.finish()


### PR DESCRIPTION
Allow Speech actor to be able to get deollacted:

Hi @stephencelis and @mbrandonw,

Thanks for reviewing the PR and providing your feedback.

Currently, the SpeechClient (the Speech actor) gets initialized when we start the Record Meeting. However, once the user navigates away from that screen, there's no longer a need to retain the actor in memory, since it is exclusively required during active speech recording sessions. The PR addresses this unnecessary retention, allowing the actor to be correctly deallocated when it's no longer in use.

Let me know if this clarifies the intention or if further details are needed!